### PR TITLE
Set the version of cells according to the README

### DIFF
--- a/cells-rails.gemspec
+++ b/cells-rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "cells", ">= 4.0"
+  spec.add_dependency "cells", ">= 4.1"
   spec.add_dependency "actionpack", ">= 3.0"
 
 


### PR DESCRIPTION
Because the cells-rails gem works with cells starting the from 4.1 version.