### PR TITLE
Fix bundler auto-require issue

### DIFF
--- a/lib/cells-rails.rb
+++ b/lib/cells-rails.rb
@@ -1,0 +1,1 @@
+require "cells/rails"


### PR DESCRIPTION
Add a primary `lib` file according to http://guides.rubygems.org/patterns/#consistent-naming