### PR TITLE
Implement view method for rails controller

### DIFF
--- a/lib/cell/rails.rb
+++ b/lib/cell/rails.rb
@@ -16,6 +16,10 @@ module Cell
       def concept(name, model=nil, options={}, &block)
         cell(name, model, options, ::Cell::Concept, &block)
       end
+
+      def view(cell, *args)
+        render html: cell(*args)
+      end
     end
 
     module ActionView


### PR DESCRIPTION
I want to try to add simple method like `view` in controller for render cells like html instead of ActionView. Also thought about such method names as: `render_cell`, `render_view`.

Maybe we also need add some sort of guessing.

``` ruby
def index
  view('product/index', Product.all)
end
```

just:

``` ruby
def index
  view Product.all # and take namespace from controller and cell from action
end
```

What do you think @apotonick ?
