### PR TITLE
make multiple template engines possible

### DIFF
--- a/lib/cell/railtie.rb
+++ b/lib/cell/railtie.rb
@@ -54,13 +54,13 @@ module Cell
       end
     end
 
-    # TODO: allow to turn off this.
     initializer "cells.include_template_module", after: "cells.include_default_helpers" do
-      # yepp, this is happening. saves me a lot of coding in each extension.
-      ViewModel.send(:include, Cell::Erb) if Cell.const_defined?(:Erb, false)
-      ViewModel.send(:include, Cell::Haml) if Cell.const_defined?(:Haml, false)
-      ViewModel.send(:include, Cell::Hamlit) if Cell.const_defined?(:Hamlit, false)
-      ViewModel.send(:include, Cell::Slim) if Cell.const_defined?(:Slim, false)
+      # just include if exactly one template engine gem is loaded
+      # otherwise we have to include it in the cells manually as needed
+      engines = [:Erb, :Haml, :Hamlit, :Slim].select { |tmpl| Cell.const_defined?(tmpl, false) }
+      if engines.size == 1
+        ViewModel.send(:include, "Cell::#{engines.first}".constantize)
+      end
     end
     #   ViewModel.template_engine = app.config.app_generators.rails.fetch(:template_engine, "erb").to_s
 


### PR DESCRIPTION
Make it possible to use multiple template engines like erb and hamlit in one project.
The problem is that it is automatically included in view context and the last inclusion wins.
What I want to have is this:
if you include one template engine like
`gem 'cells-erb'`
in your Gemfile it should be included automatically like the current behavior.
But if you want to use more engines like

```
gem 'cells-erb'
gem 'cells-hamlit'
```

nothing should be included automatically and you have to choose the right template engine per cell like

```
class MyErbCell < Trailblazer::Cell
  include ::Cell::Erb
  ...
end

class MyHamlitCell < Trailblazer::Cell
  include ::Cell::Hamlit
  ...
end
```
