### PR TITLE
ISSUE #350: fix double HTML escaping in Slim templates

### DIFF
--- a/lib/cell/rails.rb
+++ b/lib/cell/rails.rb
@@ -54,6 +54,10 @@ module Cell
         super.html_safe
       end
 
+      def html_safe?
+        true
+      end
+
       def parent_controller
         context[:controller]
       end

--- a/lib/cell/rails/collection.rb
+++ b/lib/cell/rails/collection.rb
@@ -4,6 +4,10 @@ module Cell
       def call(*)
         super.html_safe
       end
+
+      def html_safe?
+        true
+      end
     end
   end
 end

--- a/test/rails4.2/test/public_test.rb
+++ b/test/rails4.2/test/public_test.rb
@@ -7,6 +7,14 @@ class PublicTest < MiniTest::Spec
   # ViewModel.cell(collection: []) renders html_safe.
   it { Cell::ViewModel.cell("public_test/song", collection: [Object]).().class.must_equal ActiveSupport::SafeBuffer }
 
+  # ViewModel.cell(collection: []) marks itself as html_safe?
+  it { Cell::ViewModel.cell("public_test/song", collection: [Object]).must_respond_to :html_safe? }
+  it { Cell::ViewModel.cell("public_test/song", collection: [Object]).html_safe?.must_equal true }
+
   # #call returns html_safe.
   it { SongCell.new(nil).().must_be_instance_of ActiveSupport::SafeBuffer }
+
+  # A cell marks itself as html_safe?
+  it { SongCell.new(nil).must_respond_to :html_safe? }
+  it { SongCell.new(nil).html_safe?.must_equal true }
 end

--- a/test/rails5.0/test/public_test.rb
+++ b/test/rails5.0/test/public_test.rb
@@ -7,6 +7,14 @@ class PublicTest < MiniTest::Spec
   # ViewModel.cell(collection: []) renders html_safe.
   it { Cell::ViewModel.cell("public_test/song", collection: [Object]).().class.must_equal ActiveSupport::SafeBuffer }
 
+  # ViewModel.cell(collection: []) marks itself as html_safe?
+  it { Cell::ViewModel.cell("public_test/song", collection: [Object]).must_respond_to :html_safe? }
+  it { Cell::ViewModel.cell("public_test/song", collection: [Object]).html_safe?.must_equal true }
+
   # #call returns html_safe.
   it { SongCell.new(nil).().must_be_instance_of ActiveSupport::SafeBuffer }
+
+  # A cell marks itself as html_safe?
+  it { SongCell.new(nil).must_respond_to :html_safe? }
+  it { SongCell.new(nil).html_safe?.must_equal true }
 end


### PR DESCRIPTION
Slim templating engine relies on an object's `html_safe?` method to decide whether to make HTML escaping or not. Cells do not report themselves as being `html_safe?` thus forcing Slim to escape their output (`to_s`), resulting in double escaping.

This pull request adds `html_safe?` methods to Cells and Collections.