### PR TITLE
Add warning about escaping html and XSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Add this line to your application's Gemfile and keep it real:
 gem 'cells-rails'
 ```
 
+## Warnings
+
+Cells does not escape strings by default like Rails do, it can expose you to XSS attacks. You need to take care of this. For example include `ERB::Util` in cell and use h() helper. There is also `Escaped` module in Cells but it does the thing only for the properties.
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).


### PR DESCRIPTION
I just find out that my app is vulnerable to XSS attacks due to lack of html escaping in Cells. I believe people who use Rails assume that it will just work as in Rails.