### PR TITLE
Ruby 1.9 backward compatibility

### DIFF
--- a/lib/cell/railtie.rb
+++ b/lib/cell/railtie.rb
@@ -54,7 +54,7 @@ module Cell
       end
     end
 
-    IncludeTemplateModules = -> (app) do
+    IncludeTemplateModules = ->(app) do
       return if app.config.cells.include_template_engine == false
 
       # yepp, this is happening. saves me a lot of coding in each extension.


### PR DESCRIPTION
* Lambda rocket syntax in ruby 1.9 doesn't allow space between
  -> (params) vs ->(params)