### PR TITLE
  generate view folders with singular convention

### DIFF
--- a/lib/rails/generators/concept/concept_generator.rb
+++ b/lib/rails/generators/concept/concept_generator.rb
@@ -16,7 +16,7 @@ module Rails
       def create_views
         states.each do |state|
           @state = state
-          @path = File.join('app/concepts', class_path, file_name, 'views', "#{state}.#{template_engine}")
+          @path = File.join('app/concepts', class_path, file_name, 'view', "#{state}.#{template_engine}")
           template "view.#{template_engine}", @path
         end
       end

--- a/test/rails4.2/test/concept_generator_test.rb
+++ b/test/rails4.2/test/concept_generator_test.rb
@@ -12,7 +12,7 @@ class ConceptGeneratorTest < Rails::Generators::TestCase
 
     assert_file 'app/concepts/song/cell.rb', /class Song::Cell < Cell::Concept/
     assert_file 'app/concepts/song/cell.rb', /def show/
-    assert_file 'app/concepts/song/views/show.erb', %r{app/concepts/song/views/show\.erb}
+    assert_file 'app/concepts/song/view/show.erb', %r{app/concepts/song/view/show\.erb}
   end
 
   test "test unit test" do
@@ -27,7 +27,7 @@ class ConceptGeneratorTest < Rails::Generators::TestCase
 
     assert_file 'app/concepts/song/cell.rb', /class Song::Cell < Cell::Concept/
     assert_file 'app/concepts/song/cell.rb', /def show/
-    assert_file 'app/concepts/song/views/show.haml', %r{app/concepts/song/views/show\.haml}
+    assert_file 'app/concepts/song/view/show.haml', %r{app/concepts/song/view/show\.haml}
   end
 
   test '[slim] standard assets, show view' do
@@ -35,6 +35,6 @@ class ConceptGeneratorTest < Rails::Generators::TestCase
 
     assert_file 'app/concepts/song/cell.rb', /class Song::Cell < Cell::Concept/
     assert_file 'app/concepts/song/cell.rb', /def show/
-    assert_file 'app/concepts/song/views/show.slim', %r{app/concepts/song/views/show\.slim}
+    assert_file 'app/concepts/song/view/show.slim', %r{app/concepts/song/view/show\.slim}
   end
 end

--- a/test/rails5.0/test/concept_generator_test.rb
+++ b/test/rails5.0/test/concept_generator_test.rb
@@ -12,7 +12,7 @@ class ConceptGeneratorTest < Rails::Generators::TestCase
 
     assert_file 'app/concepts/song/cell.rb', /class Song::Cell < Cell::Concept/
     assert_file 'app/concepts/song/cell.rb', /def show/
-    assert_file 'app/concepts/song/views/show.erb', %r{app/concepts/song/views/show\.erb}
+    assert_file 'app/concepts/song/view/show.erb', %r{app/concepts/song/view/show\.erb}
   end
 
   test "test unit test" do
@@ -27,7 +27,7 @@ class ConceptGeneratorTest < Rails::Generators::TestCase
 
     assert_file 'app/concepts/song/cell.rb', /class Song::Cell < Cell::Concept/
     assert_file 'app/concepts/song/cell.rb', /def show/
-    assert_file 'app/concepts/song/views/show.haml', %r{app/concepts/song/views/show\.haml}
+    assert_file 'app/concepts/song/view/show.haml', %r{app/concepts/song/view/show\.haml}
   end
 
   test '[slim] standard assets, show view' do
@@ -35,6 +35,6 @@ class ConceptGeneratorTest < Rails::Generators::TestCase
 
     assert_file 'app/concepts/song/cell.rb', /class Song::Cell < Cell::Concept/
     assert_file 'app/concepts/song/cell.rb', /def show/
-    assert_file 'app/concepts/song/views/show.slim', %r{app/concepts/song/views/show\.slim}
+    assert_file 'app/concepts/song/view/show.slim', %r{app/concepts/song/view/show\.slim}
   end
 end


### PR DESCRIPTION
@apotonick 

Enforce the singular convention for view folders, per the discussion at https://github.com/trailblazer/trailblazer-cells/pull/5

note: it's a straight forward fix but the test suite seems broken so I'm not 100% sure
