### PR TITLE
Use controller class from parameter instead of context (in testing classes)

### DIFF
--- a/lib/cell/rails/testing.rb
+++ b/lib/cell/rails/testing.rb
@@ -6,15 +6,15 @@ module Cell
         return unless controller_class
 
         controller_class.new.tap do |ctl|
-          ctl.request = action_controller_test_request
+          ctl.request = action_controller_test_request(controller_class)
           ctl.instance_variable_set :@routes, ::Rails.application.routes.url_helpers
         end
       end
 
-      def action_controller_test_request
+      def action_controller_test_request(controller_class)
         if ::Rails::VERSION::MAJOR >= 5
           if ::Rails::VERSION::MINOR >= 1 # ~> 5.1
-            ::ActionController::TestRequest.create(self.class.controller_class)
+            ::ActionController::TestRequest.create(controller_class)
           else # 5.0
             ::ActionController::TestRequest.create
           end


### PR DESCRIPTION
- Based on discussion https://github.com/trailblazer/cells-rails/issues/26#issuecomment-300176909

This PR aims to fix test suites for applications using `rspec-cells` without affecting default minitest setups, by using the parameter `controller_class` instead of assuming the `controller_class` from context.

