### PR TITLE
Add cell helper to ActionMailer

### DIFF
--- a/lib/cell/rails.rb
+++ b/lib/cell/rails.rb
@@ -18,6 +18,15 @@ module Cell
       end
     end
 
+    module ActionMailer
+      def cell(name, model=nil, options={}, constant=::Cell::ViewModel, &block)
+        options[:context] ||= {}
+        options[:context][:controller] = self
+
+        constant.cell(name, model, options, &block)
+      end
+    end
+
     module ActionView
       # Returns the cell instance for +name+. You may pass arbitrary options to your
       # cell.

--- a/lib/cell/railtie.rb
+++ b/lib/cell/railtie.rb
@@ -27,6 +27,12 @@ module Cell
         end
       end
 
+      ActiveSupport.on_load(:action_mailer) do
+        self.class_eval do
+          include ::Cell::RailsExtensions::ActionMailer
+        end
+      end
+
       ActiveSupport.on_load(:action_view) do
         self.class_eval do
           include ::Cell::RailsExtensions::ActionView


### PR DESCRIPTION
To be able to use `cell` helper in mailer views as normal views.

I find it very convenient and a nice addition, so after read https://github.com/trailblazer/cells-rails/issues/14 I thought that it deserves a try :smiley:.