### PR TITLE
Added nil check to context in parent_controller.

### DIFF
--- a/lib/cell/rails.rb
+++ b/lib/cell/rails.rb
@@ -55,7 +55,7 @@ module Cell
       end
 
       def parent_controller
-        context[:controller]
+        context[:controller] if context
       end
       alias_method :controller, :parent_controller
 


### PR DESCRIPTION
When calling a cell lambda directly (not through the cell helper), it's possible to have a null context.
lib/simple_form/form_builder.rb calls cells-rails/lib/cell/rails.rb#parent_controller (through its controller)
alias but throws a nil error in this situation. I added a check against context being nil before trying
to access a key in the context.