### PR TITLE
CI: add Ruby 3.2 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, head]
+        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, head]
         gemfile:
           - gemfiles/7.0.gemfile
           - gemfiles/6.0.gemfile
@@ -21,6 +21,10 @@ jobs:
           - ruby: 3.1
             gemfile: gemfiles/5.2.gemfile
           - ruby: 3.1
+            gemfile: gemfiles/6.0.gemfile
+          - ruby: 3.2
+            gemfile: gemfiles/5.2.gemfile
+          - ruby: 3.2
             gemfile: gemfiles/6.0.gemfile
           - ruby: head
             gemfile: gemfiles/5.2.gemfile


### PR DESCRIPTION
Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! Let's add it to the CI build matrix and ensure the project is compatible.