### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/cells-rails.gemspec
+++ b/cells-rails.gemspec
@@ -14,6 +14,12 @@ Gem::Specification.new do |spec|
   spec.summary = 'Convenient Rails support for Cells.'
   spec.homepage = 'https://trailblazer.to'
 
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = 'https://github.com/trailblazer/cells-rails'
+  spec.metadata['bug_tracker_uri'] = "#{spec.metadata['source_code_uri']}/issues"
+  spec.metadata['changelog_uri'] = "#{spec.metadata['source_code_uri']}/blob/HEAD/CHANGES.md"
+  spec.metadata['documentation_uri'] = 'https://trailblazer.to/2.1/docs/cells#cells-rails'
+
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|\.github)/}) }
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
### Proposed Change

Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `homepage_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/cells-rails), via the Rubygems API, and the `gem` and `bundle` command-line tools, after the next release.